### PR TITLE
修改mod的path, 使其可以通过 go install下载

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module imaotai
+module github.com/litterGuy/imaotai
 
 go 1.19
 


### PR DESCRIPTION
go install github.com/litterGuy/imaotai@1.0.0        
go: github.com/litterGuy/imaotai@1.0.0: version constraints conflict:
        github.com/litterGuy/imaotai@v0.0.0-20230718233953-0cf6697a7193: parsing go.mod:
        module declares its path as: imaotai
                but was required as: github.com/litterGuy/imaotai

